### PR TITLE
fix: MasterIPC#restart sending `data` instead of `d`

### DIFF
--- a/src/IPC/MasterIPC.ts
+++ b/src/IPC/MasterIPC.ts
@@ -87,7 +87,7 @@ export class MasterIPC extends EventEmitter {
 		const { d: clusterID } = message.data;
 		return this.manager.restart(clusterID)
 			.then(() => message.reply({ success: true }))
-			.catch(error => message.reply({ success: false, data: { name: error.name, message: error.message, stack: error.stack } }));
+			.catch(error => message.reply({ success: false, d: { name: error.name, message: error.message, stack: error.stack } }));
 	}
 
 	private async _mastereval(message: NodeMessage) {


### PR DESCRIPTION
Though another issue persists, here: https://github.com/DevYukine/Kurasuta/blob/master/src/IPC/MasterIPC.ts#L126

Fixes this error:

```javascript
TypeError: Cannot read property 'message' of undefined
    at Function.makeError (/***/node_modules/discord.js/src/util/Util.js:316:31)
    at ShardClientUtil.restart (/***/node_modules/kurasuta/src/Sharding/ShardClientUtil.ts:62:28)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
```