### PR TITLE
Allow for options to be passed into the broadcast function

### DIFF
--- a/src/IPC/ClusterIPC.ts
+++ b/src/IPC/ClusterIPC.ts
@@ -3,15 +3,11 @@ import { Client as VezaClient, NodeMessage, ClientSocket } from 'veza';
 import { Client, Util } from 'discord.js';
 import { IPCEvents } from '../Util/Constants';
 import { IPCResult } from '..';
-import { IPCError } from '../Sharding/ShardClientUtil';
+import { IPCError, BroadcastEvalOptions } from '../Sharding/ShardClientUtil';
 
 export interface IPCRequest {
 	op: number;
 	d: string;
-}
-
-export interface BroadcastEvalOptions {
-	context?: any;
 }
 
 export class ClusterIPC extends EventEmitter {

--- a/src/IPC/ClusterIPC.ts
+++ b/src/IPC/ClusterIPC.ts
@@ -10,6 +10,10 @@ export interface IPCRequest {
 	d: string;
 }
 
+export interface BroadcastEvalOptions {
+	context?: any;
+}
+
 export class ClusterIPC extends EventEmitter {
 	public clientSocket?: ClientSocket;
 	public client: Client | typeof Client;
@@ -26,8 +30,9 @@ export class ClusterIPC extends EventEmitter {
 			.on('message', this._message.bind(this));
 	}
 
-	public async broadcast(script: string | Function) {
-		script = typeof script === 'function' ? `(${script})(this)` : script;
+	public async broadcast(script: string | Function, options?: BroadcastEvalOptions) {
+		if (options) script = typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context)})` : script;
+		else script = typeof script === 'function' ? `(${script})(this)` : script;
 		const { success, d } = await this.server.send({ op: IPCEvents.BROADCAST, d: script }) as IPCResult;
 		if (!success) throw Util.makeError(d as IPCError);
 		return d as unknown[];

--- a/src/Sharding/ShardClientUtil.ts
+++ b/src/Sharding/ShardClientUtil.ts
@@ -14,6 +14,10 @@ export interface IPCError {
 	stack: string;
 }
 
+export interface BroadcastEvalOptions {
+	context?: any;
+}
+
 export class ShardClientUtil {
 	public readonly clusterCount = Number(process.env.CLUSTER_CLUSTER_COUNT);
 	public readonly shardCount = Number(process.env.CLUSTER_SHARD_COUNT);
@@ -24,8 +28,8 @@ export class ShardClientUtil {
 	public constructor(public client: Client | typeof Client, public ipcSocket: string | number) {
 	}
 
-	public broadcastEval(script: string | Function): Promise<unknown[]> {
-		return this.ipc.broadcast(script);
+	public broadcastEval(script: string | Function, options?: BroadcastEvalOptions): Promise<unknown[]> {
+		return this.ipc.broadcast(script, options);
 	}
 
 	public masterEval(script: string | Function): Promise<unknown> {


### PR DESCRIPTION
As of discord.js v13 the [broadcastEval](https://discord.js.org/#/docs/main/stable/class/ShardClientUtil?scrollTo=broadcastEval) method allows [BroadcastEvalOptions](https://discord.js.org/#/docs/main/stable/typedef/BroadcastEvalOptions) to be passed into the method. 

This PR adds the option to pass in the BroadcastEvalOptions object to the method.